### PR TITLE
Add style to Vector

### DIFF
--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -259,6 +259,15 @@ export interface VectorBase extends Global {
    * "CENTER": draw stroke centered along the shape boundary
    */
   readonly strokeAlign: 'INSIDE' | 'OUTSIDE' | 'CENTER';
+  
+  /**
+   * Map from ID to Style for looking up style
+   */
+  readonly style: {
+    readonly fill?: Style;
+    readonly stroke?: Style;
+    readonly effect?: Style;
+  };
 }
 
 /** A vector network, consisting of vertices and edges */


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

`style` is exposed for `Vector`'s which maps to a `Style` interface which can be used for look up in `FileResponse.styles`.

Since there's really no tests for these types, I guess just validate manually?

- Create a Figma project
- Create some local styles (Color Style, and Effect Style)
- Create a shape and apply a local style to:
 - Fill
 - Stroke
 - Effect
