### PR TITLE
Updates

### DIFF
--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -25,13 +25,9 @@ export type StyleKeyType =
   | 'text'
   | 'background';
 
-export type StylesObject =
-  | { fill: string }
-  | { stroke: string }
-  | { effect: string }
-  | { grid: string }
-  | { text: string }
-  | { background: string };
+export type StylesObject = {
+  [key in StyleKeyType]: Record<key, string>
+}[StyleKeyType];
 
 export type ScaleMode = 'FILL' | 'FIT' | 'TILE' | 'STRETCH';
 

--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -589,6 +589,11 @@ export interface Paint {
   // for solid paints
   /** Solid color of the paint */
   readonly color?: Color;
+  /**
+   * How this node blends with nodes behind it in the scene
+   * (see blend mode section for more details)
+   */
+  readonly blendMode: BlendMode;
   // for gradient paints
   /**
    * This field contains three vectors, each of which are a position in
@@ -608,14 +613,24 @@ export interface Paint {
    * between neighboring gradient stops.
    */
   readonly gradientStops?: ReadonlyArray<ColorStop>;
+
   // for image paints
+
   /** Image scaling mode */
   readonly scaleMode?: ScaleMode;
   /**
-   * How this node blends with nodes behind it in the scene
-   * (see blend mode section for more details)
+   * Affine transform applied to the image, only present if scaleMode is `STRETCH`
    */
-  readonly blendMode: BlendMode;
+  readonly imageTransform?: Transform;
+  /**
+   * Amount image is scaled by in tiling, only present if scaleMode is `TILE`
+   */
+  readonly scalingFactor?: number;
+  /**
+   * A reference to an image embedded in the file. To download the image using this reference,
+   * use the GET file images endpoint to retrieve the mapping from image references to image URLs
+   */
+  readonly imageRef?: string;
 }
 
 export interface Path {

--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -692,6 +692,8 @@ export interface Component {
 export interface Style {
   /** The name of the stlye */
   readonly name: string;
+  /** A description of the style */
+  readonly description: string;
   /** The unique identifier of the style */
   readonly key: string;
   /** The type of style */

--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -25,7 +25,13 @@ export type StyleKeyType =
   | 'text'
   | 'background';
 
-export type StylesObject = { [K in StyleKeyType]?: string };
+export type StylesObject =
+  | { fill: string }
+  | { stroke: string }
+  | { effect: string }
+  | { grid: string }
+  | { text: string }
+  | { background: string };
 
 export type ScaleMode = 'FILL' | 'FIT' | 'TILE' | 'STRETCH';
 

--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -763,6 +763,16 @@ export interface FileImageResponse {
   };
 }
 
+export interface FileImageFillsResponse {
+  readonly error: boolean;
+  readonly status: number;
+  readonly meta: {
+    images: {
+      readonly [key: string]: string;
+    };
+  };
+}
+
 export interface CommentsResponse {
   readonly comments: ReadonlyArray<Comment>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,23 @@ export interface ClientInterface {
   ) => AxiosPromise<Figma.FileImageResponse>;
 
   /**
+   * Returns download links for all images present in image fills in a document.
+   * Image fills are how Figma represents any user supplied images.
+   * When you drag an image into Figma, we create a rectangle with a single
+   * fill that represents the image, and the user is able to transform the
+   * rectangle (and properties on the fill) as they wish.
+   *
+   * This endpoint returns a mapping from image references to the URLs at which
+   * the images may be download. Image URLs will expire after no more than 14 days.
+   * Image references are located in the output of the GET files endpoint under the
+   * imageRef attribute in a Paint.
+   * @param {fileId} String File to export images from
+   */
+  readonly fileImageFills: (
+    fileId: string
+  ) => AxiosPromise<Figma.FileImageFillsResponse>;
+
+  /**
    * A list of comments left on the file
    * @param {fileId} String File to get comments from
    */
@@ -142,6 +159,8 @@ export const Client = (opts: ClientOptions): ClientInterface => {
           ids: params.ids.join(',')
         }
       }),
+
+    fileImageFills: fileId => client.get(`files/${fileId}/images`),
 
     comments: fileId => client.get(`files/${fileId}/comments`),
 


### PR DESCRIPTION
- updating `StylesObject` so it no longer supports the invalid `{}`
- adding the image fill endpoint from Figma (https://www.figma.com/developers/api#get-image-fills-endpoint)
