### PR TITLE
Add missing endpoints

### DIFF
--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -784,6 +784,25 @@ export interface FileResponse {
   readonly version: string;
 }
 
+export interface FileNodesResponse {
+  readonly nodes: {
+    readonly [key: string]: null | {
+      readonly document: Node;
+      readonly components: {
+        readonly [key: string]: ComponentMetadata;
+      };
+      readonly styles: {
+        readonly [key: string]: Style;
+      };
+      readonly schemaVersion: number;
+    };
+  };
+  readonly lastModified: string;
+  readonly name: string;
+  readonly thumbnailUrl: string;
+  readonly version: string;
+}
+
 export interface FileImageResponse {
   readonly err: string | null;
   readonly images: {

--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -707,12 +707,55 @@ export interface TypeStyle {
  * instances are attached to
  */
 export interface ComponentMetadata {
-  /** The componens key */
+  /** The unique identifier of the element */
   readonly key: string;
-  /** The name of the component */
+  /** The name of the element */
   readonly name: string;
-  /** The description of the component as entered in the editor */
+  /** The description of the element as entered in the editor */
   readonly description: string;
+}
+
+export interface FrameInfo {
+  /** Id of the frame node within the figma file */
+  readonly node_id: string;
+  /** The name of the frame */
+  readonly name: string;
+  /** Background color of the frame */
+  readonly background_color: string;
+  /** Id of the frame's residing page */
+  readonly page_id: string;
+  /** Name of the frame's residing page */
+  readonly page_name: string;
+}
+
+interface SharedElement extends ComponentMetadata {
+  /** The unique identifier of the figma file which contains the element */
+  readonly file_key: string;
+  /** URL link to the element's thumbnail image */
+  readonly thumbnail_urlString: string;
+  /** The UTC ISO 8601 time at which the element was created */
+  readonly created_at: string;
+  /** The UTC ISO 8601 time at which the element was updated */
+  readonly updated_at: string;
+  /** The user who last updated the element */
+  readonly user: User;
+}
+
+/**
+ * An arrangement of published UI elements that can be instantiated across figma files
+ */
+export interface FullComponentMetadata extends SharedElement {
+  /** Data on component's containing frame, if component resides within a frame */
+  readonly containing_frame: FrameInfo;
+  /** Data on component's containing page, if component resides in a multi-page file */
+  readonly containing_page: any; // broken link in the doc
+}
+
+export interface FullStyleMetadata extends SharedElement {
+  /** The type of style */
+  readonly style_type: StyleType;
+  /** A user specified order number by which the style can be sorted */
+  readonly sort_position: string;
 }
 
 /**
@@ -858,4 +901,19 @@ export interface TeamProjectsResponse {
 
 export interface ProjectFilesResponse {
   readonly files: ReadonlyArray<FileSummary>;
+}
+
+interface PaginationResponse {
+  readonly cursor: {
+    readonly before: number;
+    readonly after: number;
+  };
+}
+
+export interface TeamComponentsResponse extends PaginationResponse {
+  readonly components: ReadonlyArray<FullComponentMetadata>;
+}
+
+export interface TeamStylesResponse extends PaginationResponse {
+  readonly styles: ReadonlyArray<FullStyleMetadata>;
 }

--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -760,7 +760,11 @@ export interface Comment {
 
 /** A description of a user */
 export interface User {
+  /** Unique stable id of the user */
+  readonly id: string;
+  /** Name of the user */
   readonly handle: string;
+  /** URL link to the user's profile image */
   readonly img_url: string;
 }
 
@@ -801,6 +805,23 @@ export interface FileNodesResponse {
   readonly name: string;
   readonly thumbnailUrl: string;
   readonly version: string;
+}
+
+export interface VersionMetadata {
+  /** Unique identifier for version */
+  readonly id: string;
+  /** The UTC ISO 8601 time at which the version was created */
+  readonly created_at: string;
+  /** The label given to the version in the editor */
+  readonly label: string;
+  /** The description of the version as entered in the editor */
+  readonly description: string;
+  /** The user that created the version */
+  readonly user: User;
+}
+
+export interface FileVersionsResponse {
+  readonly versions: ReadonlyArray<VersionMetadata>;
 }
 
 export interface FileImageResponse {

--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -26,7 +26,7 @@ export type StyleKeyType =
   | 'background';
 
 export type StylesObject = {
-  [key in StyleKeyType]: Record<key, string>
+  [key in StyleKeyType]: Record<key, string>;
 }[StyleKeyType];
 
 export type ScaleMode = 'FILL' | 'FIT' | 'TILE' | 'STRETCH';
@@ -795,7 +795,7 @@ export interface FileImageFillsResponse {
   readonly error: boolean;
   readonly status: number;
   readonly meta: {
-    images: {
+    readonly images: {
       readonly [key: string]: string;
     };
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,6 +180,12 @@ export interface ClientInterface {
   ) => AxiosPromise<Figma.Comment>;
 
   /**
+   * Get user information for the authenticated user.
+   * @see https://www.figma.com/developers/api#get-me-endpoint
+   */
+  readonly me: () => AxiosPromise<Figma.User & { readonly email: string }>;
+
+  /**
    * Lists the projects for a specified team. Note that this will only
    * return projects visible to the authenticated user or owner of the
    * developer token.
@@ -243,6 +249,8 @@ export const Client = (opts: ClientOptions): ClientInterface => {
 
     postComment: (fileId, params) =>
       client.post(`files/${fileId}/comments`, params),
+
+    me: () => client.get(`me`),
 
     teamProjects: teamId => client.get(`teams/${teamId}/projects`),
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export interface ClientInterface {
    * https://www.figma.com/file/:key/:title.
    * The "document" attribute contains a Node of type DOCUMENT.
    * @param {fileId} String File to export JSON from
+   * @see https://www.figma.com/developers/api#get-files-endpoint
    */
   readonly file: (
     fileId: string,
@@ -92,6 +93,7 @@ export interface ClientInterface {
    * map whether or not the render succeeded.
    * @param {fileId} String File to export images from
    * @param {params} FileImageParams
+   * @see https://www.figma.com/developers/api#get-images-endpoint
    */
   readonly fileImages: (
     fileId: string,
@@ -110,6 +112,7 @@ export interface ClientInterface {
    * Image references are located in the output of the GET files endpoint under the
    * imageRef attribute in a Paint.
    * @param {fileId} String File to export images from
+   * @see https://www.figma.com/developers/api#get-image-fills-endpoint
    */
   readonly fileImageFills: (
     fileId: string
@@ -118,6 +121,7 @@ export interface ClientInterface {
   /**
    * A list of comments left on the file
    * @param {fileId} String File to get comments from
+   * @see https://www.figma.com/developers/api#get-comments-endpoint
    */
   readonly comments: (fileId: string) => AxiosPromise<Figma.CommentsResponse>;
 
@@ -125,6 +129,7 @@ export interface ClientInterface {
    * Posts a new comment on the file.
    * @param {fileId} String File to get comments from
    * @param {params} PostCommentParams
+   * @see https://www.figma.com/developers/api#post-comments-endpoint
    */
   readonly postComment: (
     fileId: string,
@@ -136,6 +141,7 @@ export interface ClientInterface {
    * return projects visible to the authenticated user or owner of the
    * developer token.
    * @param {teamId} String Id of the team to list projects from
+   * @see https://www.figma.com/developers/api#get-team-projects-endpoint
    */
   readonly teamProjects: (
     teamId: string
@@ -144,6 +150,7 @@ export interface ClientInterface {
   /**
    * List the files in a given project.
    * @param {projectId} String Id of the project to list files from
+   * @see https://www.figma.com/developers/api#get-project-files-endpoint
    */
   readonly projectFiles: (
     projectId: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,8 @@ export interface FileImageParams {
   readonly svg_include_id?: boolean;
   /**
    * Whether to simplify inside/outside strokes and use stroke attribute if
-   * possible instead of <mask>. Default: true.
-   * @default false
+   * possible instead of <mask>.
+   * @default true
    */
   readonly svg_simplify_stroke?: boolean;
   /** A specific version ID to use. Omitting this will use the current version of the file */

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,19 @@ export interface PostCommentParams {
   readonly client_meta: Figma.Vector2;
 }
 
+export interface PaginationParams {
+  /**
+   * Number of items in a paged list of results.
+   * @default 30
+   */
+  readonly page_size?: number;
+  /**
+   * A map that indicates the starting/ending point from which objects are returned.
+   * The cursor value is an internally tracked integer that doesn't correspond to any Ids
+   */
+  readonly cursor?: { readonly before?: number; readonly after?: number };
+}
+
 export interface ClientOptions {
   /** access token returned from OAuth authentication */
   readonly accessToken?: string;
@@ -204,6 +217,42 @@ export interface ClientInterface {
   readonly projectFiles: (
     projectId: string
   ) => AxiosPromise<Figma.ProjectFilesResponse>;
+
+  /**
+   * Get a paginated list of published components within a team library
+   * @param {teamId} String Id of the team to list components from
+   * @see https://www.figma.com/developers/api#get-team-components-endpoint
+   */
+  readonly teamComponents: (
+    teamId: string,
+    params?: PaginationParams
+  ) => AxiosPromise<Figma.TeamComponentsResponse>;
+
+  /**
+   * Get metadata on a component by key.
+   * @param {key} The unique identifier of the component.
+   * @see https://www.figma.com/developers/api#get-component-endpoint
+   */
+  readonly component: (
+    key: string
+  ) => AxiosPromise<Figma.FullComponentMetadata>;
+
+  /**
+   * Get a paginated list of published styles within a team library
+   * @param {teamId} String Id of the team to list components from
+   * @see https://www.figma.com/developers/api#get-team-styles-endpoint
+   */
+  readonly teamStyles: (
+    teamId: string,
+    params?: PaginationParams
+  ) => AxiosPromise<Figma.TeamStylesResponse>;
+
+  /**
+   * Get metadata on a style by key.
+   * @param {key} The unique identifier of the style.
+   * @see https://www.figma.com/developers/api#get-style-endpoint
+   */
+  readonly style: (key: string) => AxiosPromise<Figma.FullStyleMetadata>;
 }
 
 export const Client = (opts: ClientOptions): ClientInterface => {
@@ -254,6 +303,16 @@ export const Client = (opts: ClientOptions): ClientInterface => {
 
     teamProjects: teamId => client.get(`teams/${teamId}/projects`),
 
-    projectFiles: projectId => client.get(`projects/${projectId}/files`)
+    projectFiles: projectId => client.get(`projects/${projectId}/files`),
+
+    teamComponents: (teamId, params = {}) =>
+      client.get(`teams/${teamId}/components`, { params }),
+
+    component: key => client.get(`components/${key}`),
+
+    teamStyles: (teamId, params = {}) =>
+      client.get(`teams/${teamId}/styles`, { params }),
+
+    style: key => client.get(`styles/${key}`)
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,26 @@ export * from './figmaTypes';
 import axios, { AxiosInstance, AxiosPromise } from 'axios';
 
 export interface FileParams {
-  // a string representing the id of the file
-  readonly fileId?: string;
-  // a string representing the specific version ID to retrieve
+  /**
+   * Comma separated list of nodes that you care about in the document.
+   * If specified, only a subset of the document will be returned corresponding to the nodes listed, their children, and everything between the root node and the listed nodes
+   */
+  readonly ids?: string;
+
+  /**
+   * Positive integer representing how deep into the document tree to traverse.
+   * For example, setting this to 1 returns only Pages, setting it to 2 returns Pages and all top level objects on each page.
+   * Not setting this parameter returns all nodes
+   */
+  readonly depth?: number;
+
+  /**
+   * A specific version ID to get. Omitting this will get the current version of the file
+   */
   readonly version?: string;
-  // returned data includes path data or not
+  /**
+   * Set to "paths" to export vector data
+   */
   readonly geometry?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,22 @@ export interface FileParams {
    * A specific version ID to get. Omitting this will get the current version of the file
    */
   readonly version?: string;
+
+  /**
+   * Set to "paths" to export vector data
+   */
+  readonly geometry?: string;
+}
+
+export interface FileNodesParams {
+  /** A list of node IDs to retrieve and convert */
+  readonly ids: ReadonlyArray<string>;
+
+  /**
+   * A specific version ID to get. Omitting this will get the current version of the file
+   */
+  readonly version?: string;
+
   /**
    * Set to "paths" to export vector data
    */
@@ -81,6 +97,20 @@ export interface ClientInterface {
     fileId: string,
     params?: FileParams
   ) => AxiosPromise<Figma.FileResponse>;
+
+  /**
+   * Returns the nodes referenced to by :ids as a JSON object.
+   * The nodes are retrieved from the Figma file referenced to by :key.
+   * The node Id and file key can be parsed from any Figma node url:
+   * https://www.figma.com/file/:key/:title?node-id=:id.
+   * @param {fileId} String File to export JSON from
+   * @param {params} FileNodesParams
+   * @see https://www.figma.com/developers/api#get-file-nodes-endpoint
+   */
+  readonly fileNodes: (
+    fileId: string,
+    params: FileNodesParams
+  ) => AxiosPromise<Figma.FileNodesResponse>;
 
   /**
    * If no error occurs, "images" will be populated with a map from
@@ -175,6 +205,14 @@ export const Client = (opts: ClientOptions): ClientInterface => {
     client,
 
     file: (fileId, params = {}) => client.get(`files/${fileId}`, { params }),
+
+    fileNodes: (fileId, params) =>
+      client.get(`files/${fileId}/nodes`, {
+        params: {
+          ...params,
+          ids: params.ids.join(',')
+        }
+      }),
 
     fileImages: (fileId, params) =>
       client.get(`images/${fileId}`, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,19 @@ export interface ClientInterface {
   ) => AxiosPromise<Figma.FileResponse>;
 
   /**
+   * Returns a list of the versions of a file.
+   * The file key can be parsed from any Figma node url:
+   * https://www.figma.com/file/:key/:title.
+   * @param {fileId} String File to get version history from
+   * @see https://www.figma.com/developers/api#get-file-versions-endpoint
+   */
+  readonly fileVersions: (
+    fileId: string,
+    ids: ReadonlyArray<string>,
+    params?: FileNodesParams
+  ) => AxiosPromise<Figma.FileVersionsResponse>;
+
+  /**
    * Returns the nodes referenced to by :ids as a JSON object.
    * The nodes are retrieved from the Figma file referenced to by :key.
    * The node Id and file key can be parsed from any Figma node url:
@@ -205,6 +218,8 @@ export const Client = (opts: ClientOptions): ClientInterface => {
     client,
 
     file: (fileId, params = {}) => client.get(`files/${fileId}`, { params }),
+
+    fileVersions: fileId => client.get(`files/${fileId}/versions`),
 
     fileNodes: (fileId, params) =>
       client.get(`files/${fileId}/nodes`, {


### PR DESCRIPTION
There were a bunch of endpoints missing, this PR adds them. It also adds a link to each endpoint documentation (using the `@see` JS Doc tag)
