### PR TITLE
API additions

### DIFF
--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -637,6 +637,12 @@ export interface Paint {
    * use the GET file images endpoint to retrieve the mapping from image references to image URLs
    */
   readonly imageRef?: string;
+  /**
+   * A reference to the GIF embedded in this node, if the image is a GIF. 
+   * To download the image using this reference, 
+   * use the GET file images endpoint to retrieve the mapping from image references to image URLs
+   */
+  readonly gifRef?: string;
 }
 
 export interface Path {

--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -734,6 +734,14 @@ export interface FrameInfo {
   readonly page_name: string;
 }
 
+/** A relative offset within a frame */
+export interface FrameOffset {
+  /** Unique id specifying the frame */
+  readonly node_id: string
+  /** 2d vector offset within the frame */
+  readonly node_offset: Vector2
+}
+
 interface SharedElement extends ComponentMetadata {
   /** The unique identifier of the figma file which contains the element */
   readonly file_key: string;
@@ -799,7 +807,7 @@ export interface Comment {
    * The content of the comment
    */
   readonly message: string;
-  readonly client_meta: Vector2;
+  readonly client_meta: Vector2 | FrameOffset;
   /**
    * Only set for top level comments. The number displayed with the
    * comment in the UI

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export interface PostCommentParams {
   /** The text contents of the comment to post */
   readonly message: string;
   /** The absolute canvas position of where to place the comment */
-  readonly client_meta: Figma.Vector2;
+  readonly client_meta: Figma.Vector2 | Figma.FrameOffset;
 }
 
 export interface PaginationParams {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Added types to align with new-ish data returned by the API

* **What is the current behavior?** (You can also link to an open issue here)
1. Doesn't account for newly added **gifRef**
2. The current implementation assumes a comment is placed directly on the canvas not on a Frame. However a comment can also be placed on a Frame and if so will return a **FrameOffset** rather than a **Vector**

* **What is the new behavior (if this is a feature change)?**
1. added `Paint.gifRef: string`
2. Added `Comment.client_meta: Vector2 | FrameOffset`

* **Other information**:
