### PR TITLE
Updated: FileStyleResponse FileComponentsResponse

### DIFF
--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -918,6 +918,7 @@ export interface ComponentResponse {
 
 export interface StyleResponse {
   readonly err: string | null;
+  readonly status: number;
   readonly meta: {
     readonly [key: string]: FullStyleMetadata;
   };
@@ -951,7 +952,7 @@ export interface TeamComponentsResponse extends PaginationResponse {
   readonly components: ReadonlyArray<FullComponentMetadata>;
 }
 
-export interface FileComponentsResponse extends PaginationResponse {
+export interface FileComponentsResponse extends ComponentResponse {
   readonly components: ReadonlyArray<FullComponentMetadata>;
 }
 
@@ -959,6 +960,6 @@ export interface TeamStylesResponse extends PaginationResponse {
   readonly styles: ReadonlyArray<FullStyleMetadata>;
 }
 
-export interface FileStylesResponse extends PaginationResponse {
+export interface FileStylesResponse extends StyleResponse {
   readonly styles: ReadonlyArray<FullStyleMetadata>;
 }


### PR DESCRIPTION
https://www.figma.com/developers/api#get-file-styles-endpoint
https://www.figma.com/developers/api#get-file-components-endpoint

the file styles and file components endpoints do not return a paginated response.

* **What kind of change does this PR introduce?**
bug in Typescript types