### PR TITLE
fix style and component types

### DIFF
--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -988,19 +988,15 @@ export interface CommentsResponse {
 }
 
 export interface ComponentResponse {
-  readonly err: string | null;
+  readonly error: boolean;
   readonly status: number;
-  readonly meta: {
-    readonly [key: string]: FullComponentMetadata;
-  };
+  readonly meta: FullComponentMetadata;
 }
 
 export interface StyleResponse {
-  readonly err: string | null;
+  readonly error: boolean;
   readonly status: number;
-  readonly meta: {
-    readonly [key: string]: FullStyleMetadata;
-  };
+  readonly meta: FullStyleMetadata;
 }
 
 export interface FileSummary {
@@ -1020,25 +1016,43 @@ export interface ProjectFilesResponse {
   readonly files: ReadonlyArray<FileSummary>;
 }
 
-interface PaginationResponse {
+interface PaginationMeta {
   readonly cursor: {
     readonly before: number;
     readonly after: number;
   };
 }
 
-export interface TeamComponentsResponse extends PaginationResponse {
-  readonly components: ReadonlyArray<FullComponentMetadata>;
+export interface TeamComponentsResponse {
+  readonly error: boolean;
+  readonly status: number;
+  readonly meta: {
+    readonly components: ReadonlyArray<FullComponentMetadata>;
+    readonly cursor: PaginationMeta;
+  };
 }
 
-export interface FileComponentsResponse extends ComponentResponse {
-  readonly components: ReadonlyArray<FullComponentMetadata>;
+export interface FileComponentsResponse {
+  readonly error: boolean;
+  readonly status: number;
+  readonly meta: {
+    readonly components: ReadonlyArray<FullComponentMetadata>;
+  };
 }
 
-export interface TeamStylesResponse extends PaginationResponse {
-  readonly styles: ReadonlyArray<FullStyleMetadata>;
+export interface TeamStylesResponse {
+  readonly error: boolean;
+  readonly status: number;
+  readonly meta: {
+    readonly styles: ReadonlyArray<FullStyleMetadata>;
+    readonly cursor: PaginationMeta;
+  };
 }
 
-export interface FileStylesResponse extends StyleResponse {
-  readonly styles: ReadonlyArray<FullStyleMetadata>;
+export interface FileStylesResponse {
+  readonly error: boolean;
+  readonly status: number;
+  readonly meta: {
+    readonly styles: ReadonlyArray<FullStyleMetadata>;
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,13 +242,12 @@ export interface ClientInterface {
   ) => AxiosPromise<Figma.TeamComponentsResponse>;
 
   /**
-   * Get a paginated list of published components within a file
+   * Get a list of published components within a file
    * @param {fileId} String Id of the file to list components from
    * @see https://www.figma.com/developers/api#get-file-components-endpoint
    */
   readonly fileComponents: (
-    fileId: string,
-    params?: PaginationParams
+    fileId: string
   ) => AxiosPromise<Figma.FileComponentsResponse>;
 
   /**
@@ -270,13 +269,12 @@ export interface ClientInterface {
   ) => AxiosPromise<Figma.TeamStylesResponse>;
 
   /**
-   * Get a paginated list of published styles within a file
+   * Get a list of published styles within a file
    * @param {fileId} String Id of the file to list styles from
    * @see https://www.figma.com/developers/api#get-file-styles-endpoint
    */
   readonly fileStyles: (
-    fileId: string,
-    params?: PaginationParams
+    fileId: string
   ) => AxiosPromise<Figma.FileStylesResponse>;
 
   /**
@@ -343,16 +341,14 @@ export const Client = (opts: ClientOptions): ClientInterface => {
     teamComponents: (teamId, params = {}) =>
       client.get(`teams/${teamId}/components`, { params }),
 
-    fileComponents: (fileId, params = {}) =>
-      client.get(`files/${fileId}/components`, { params }),
+    fileComponents: fileId => client.get(`files/${fileId}/components`),
 
     component: key => client.get(`components/${key}`),
 
     teamStyles: (teamId, params = {}) =>
       client.get(`teams/${teamId}/styles`, { params }),
 
-    fileStyles: (fileId, params = {}) =>
-      client.get(`files/${fileId}/styles`, { params }),
+    fileStyles: fileId => client.get(`files/${fileId}/styles`),
 
     style: key => client.get(`styles/${key}`)
   };


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix for #34

* **What is the current behavior?** (You can also link to an open issue here)

The type definitions for the library item endpoints do not match what the API expects/returns: https://www.figma.com/developers/api#library-items-endpoints

* **What is the new behavior (if this is a feature change)?**

The types should now be correct.

* **Other information**:

The original bug was for the style endpoints, but I noticed the component endpoints had the same problems so I corrected them also, as well as removing the unsupported pagination parameters from the file style and component client methods.
