### PR TITLE
feat: change ids params of file method from string to array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,10 @@ import axios, { AxiosInstance, AxiosPromise } from 'axios';
 
 export interface FileParams {
   /**
-   * Comma separated list of nodes that you care about in the document.
+   * A list of nodes that you care about in the document.
    * If specified, only a subset of the document will be returned corresponding to the nodes listed, their children, and everything between the root node and the listed nodes
    */
-  readonly ids?: string;
+  readonly ids?: ReadonlyArray<string>;
 
   /**
    * Positive integer representing how deep into the document tree to traverse.
@@ -302,7 +302,13 @@ export const Client = (opts: ClientOptions): ClientInterface => {
   return {
     client,
 
-    file: (fileId, params = {}) => client.get(`files/${fileId}`, { params }),
+    file: (fileId, params = {}) =>
+      client.get(`files/${fileId}`, {
+        params: {
+          ...params,
+          ids: params.ids.join(',')
+        }
+      }),
 
     fileVersions: fileId => client.get(`files/${fileId}/versions`),
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature (kinda)

* **What is the current behavior?** (You can also link to an open issue here)

The file method currently accepts a string (which is comma separated list) for the `ids` params.

* **What is the new behavior (if this is a feature change)?**

To be coherent with other `ids` params, the file method now takes an array of string instead of a
string.

