### PR TITLE
Fix issue with optional ids param

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -312,7 +312,7 @@ export const Client = (opts: ClientOptions): ClientInterface => {
       client.get(`files/${fileId}`, {
         params: {
           ...params,
-          ids: params.ids.join(','),
+          ids: params.ids ? params.ids.join(',') : '',
         },
       }),
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
 
     /* Strict Type-Checking Options */
     // "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
-    // "strictNullChecks": true /* Enable strict null checks. */,
+    "strictNullChecks": true /* Enable strict null checks. */,
     // "strictFunctionTypes": true /* Enable strict checking of function types. */,
     // "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
     // "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,


### PR DESCRIPTION
* Guard against nullish ids param.
* add strict null checks to prevent this in the future.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
https://github.com/jongold/figma-js/issues/40
```
            params: Object.assign(Object.assign({}, params), { ids: params.ids.join(',') }),
                                                                               ^

TypeError: Cannot read property 'join' of undefined
```


* **What is the new behavior (if this is a feature change)?**
Allows params and params.ids to be optional again


* **Other information**:
