### PR TITLE
Fix params for fileVersions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,9 +127,7 @@ export interface ClientInterface {
    * @see https://www.figma.com/developers/api#get-file-versions-endpoint
    */
   readonly fileVersions: (
-    fileId: string,
-    ids: ReadonlyArray<string>,
-    params?: FileNodesParams
+    fileId: string
   ) => AxiosPromise<Figma.FileVersionsResponse>;
 
   /**


### PR DESCRIPTION
https://www.figma.com/developers/api#get-file-versions-endpoint

The file versions endpoint is only accepting a `key` parameter. This PR fixes the type.