### PR TITLE
fix: double cursor property typing

### DIFF
--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -1017,10 +1017,8 @@ export interface ProjectFilesResponse {
 }
 
 interface PaginationMeta {
-  readonly cursor: {
-    readonly before: number;
-    readonly after: number;
-  };
+  readonly before: number;
+  readonly after: number;
 }
 
 export interface TeamComponentsResponse {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

Typing for `TeamComponentsResponse` and `TeamStylesResponse` has pagination fields typed as:
```
response.meta.cursor.cursor.{after|before}`
```

* **What is the new behavior (if this is a feature change)?**

Typing for `TeamComponentsResponse` and `TeamStylesResponse` has corrected typing for pagination meta:
```
response.meta.cursor.{after|before}
```

* **Other information**:

Figma API:
https://www.figma.com/developers/api#get-team-styles-endpoint
```
{
  "status": Number,
  "error": Boolean,
  "meta": { 
    "styles": [
      {
       "key": String,
       "file_key": String,
       "node_id": String,
       "style_type": StyleType,
       "thumbnail_url": String,
       "name": String,
       "description": String,
       "updated_at": String,
       "created_at": String,
       "sort_position": String,
       "user": User, 
       },
      ...
    ],
    "cursor": { 
      "before": Number,
      "after": Number,
    }, 
   }, 
}
```
