### PR TITLE
feat: add support of http agents and proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ const client = Figma.Client({
 });
 ```
 
+Or if you need to use a https proxy agent:
+
+```typescript
+import * as Figma from 'figma-js';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+const token = '12345';
+const proxyAgent = new HttpsProxyAgent(process.env.https_proxy);
+
+const client = Figma.Client({
+  accessToken: token,
+  httpsAgent: proxyAgent,
+  proxy: false
+});
+```
+
 ### Doing cool things
 
 Once you have instantiated a client, have fun!

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // export * from './lib/number';
 import * as Figma from './figmaTypes';
 export * from './figmaTypes';
-import axios, { AxiosInstance, AxiosPromise } from 'axios';
+import axios, { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
 
 export interface FileParams {
   /**
@@ -107,7 +107,10 @@ export interface PaginationParams {
   readonly cursor?: { readonly before?: number; readonly after?: number };
 }
 
-export interface ClientOptions {
+export interface ClientOptions
+  extends Readonly<
+    Pick<AxiosRequestConfig, 'proxy' | 'httpAgent' | 'httpsAgent'>
+  > {
   /** access token returned from OAuth authentication */
   readonly accessToken?: string;
   /** personal access token obtained from account settings */
@@ -340,6 +343,9 @@ export const Client = (opts: ClientOptions): ClientInterface => {
       };
 
   const client = axios.create({
+    proxy: opts.proxy,
+    httpAgent: opts.httpAgent,
+    httpsAgent: opts.httpsAgent,
     baseURL: `https://${opts.apiRoot || 'api.figma.com'}/v1/`,
     headers,
   });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Add the possibility to provide a custom http agent on figma-js client instantiation.
This allows figma-js to be used in different environments (proxy,...)

* **What is the current behavior?** (You can also link to an open issue here)

The current version of figma-js can only be used with a direct internet connection.
In specific cases such as in a company environment (example: need a proxy to connect internet), figma-js does not work.

* **What is the new behavior (if this is a feature change)?**

Allowing a client to change http_agent, https_agent, or/and proxy values of axios configuration enables developers to make clients that work in more environments, such as (but not limited to) using http_proxy environment if present to connect via proxy.

* **Other information**:

Figma-js interface is kept the same (new values are optional), so it is backward compatible.
