### PR TITLE
add absoluteRenderBounds field

### DIFF
--- a/src/figmaTypes.ts
+++ b/src/figmaTypes.ts
@@ -235,6 +235,8 @@ export interface FrameBase extends Global {
   readonly opacity?: number;
   /** Bounding box of the node in absolute space coordinates */
   readonly absoluteBoundingBox: Rect;
+  /** The bounds of the rendered node in the file in absolute space coordinates */
+  readonly absoluteRenderBounds: Rect;
 
   /**
    * Width and height of element. This is different from the width and height
@@ -403,6 +405,8 @@ export interface VectorBase extends Global {
   readonly opacity?: number;
   /** Bounding box of the node in absolute space coordinates */
   readonly absoluteBoundingBox: Rect;
+  /** The bounds of the rendered node in the file in absolute space coordinates */
+  readonly absoluteRenderBounds: Rect;
 
   /**
    * Width and height of element. This is different from the width and height
@@ -545,6 +549,8 @@ export interface Slice extends Global {
   readonly exportSettings: ReadonlyArray<ExportSetting>;
   /** Bounding box of the node in absolute space coordinates */
   readonly absoluteBoundingBox: Rect;
+  /** The bounds of the rendered node in the file in absolute space coordinates */
+  readonly absoluteRenderBounds: Rect;
   /**
    * Width and height of element. This is different from the width and height
    * of the bounding box in that the absolute bounding box represents the


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adding the field `absoluteRenderBounds` to `FrameBase`, `VectorBase`, and `Slice`. (reference: https://www.figma.com/developers/api)


* **What is the current behavior?** (You can also link to an open issue here)
The field does not exist.


* **What is the new behavior (if this is a feature change)?**
The field is now available to use in TypeScript.


* **Other information**:
